### PR TITLE
Fix: Remove --no-scripts flag from CI workflow

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
     - name: Install Dependencies
-      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+      run: composer install -q --no-ansi --no-interaction --no-progress --prefer-dist
     - name: Generate key
       run: php artisan key:generate
     - name: Directory Permissions


### PR DESCRIPTION
Removes the --no-scripts flag from the composer install step in GitHub Actions to allow essential post-install scripts like artisan package:discover to run. Closes #18.