### PR TITLE
fix: prevent 419 CSRF error by updating default APP_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+# Sesuaikan APP_URL dengan URL akses browser (misal: 127.0.0.1 vs localhost) untuk mencegah error 419 CSRF
+APP_URL=http://localhost:8000
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null


### PR DESCRIPTION
Closes #47. Updated \.env.example\ to use \http://localhost:8000\ and added a comment about domain mismatch to prevent CSRF 419 Page Expired errors.